### PR TITLE
corrected gelf information link

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 PHP class to send GELF (Graylog extended log format) messages
 
-See http://www.graylog2.org/gelf for more information.
+See http://www.graylog2.org/about/gelf for more information.


### PR DESCRIPTION
Before: http://www.graylog2.org/gelf
After: http://www.graylog2.org/about/gelf
