### PR TITLE
Add a composer.json file to support Composer (http://getcomposer.org/).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ nbproject
 .buildpath
 .project
 .settings/
+composer.phar
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "graylog2/gelf-php",
+    "description": "PHP classes to send GELF (Graylog extended log format) messages",
+    "keywords": ["log","logging"],
+    "homepage": "http://github.com/Graylog2/gelf-php",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Lennart Koopmann",
+            "email": "lennart@socketfeed.com",
+            "homepage": "http://www.lennartkoopmann.net/"
+        }
+    ],
+    "autoload": {
+        "classmap": [""]
+    },
+    "require": {}
+}


### PR DESCRIPTION
This adds a `composer.json` file that describes gelf-php and will allow people to install it with [Composer](http://getcomposer.org/) by referring to the GitHub repo in their `composer.json` (see http://getcomposer.org/doc/05-repositories.md#vcs for details on how this would work).

A nice follow-up to this would be to publish gelf-php on [packagist](http://packagist.org/); then people will be able to install it even more easily without having to add a custom repo to their `composer.json`.

See [my gelf-php-test repo](https://github.com/msabramo/gelf-php-test), which illustrates how to use a [`composer.json`](https://github.com/msabramo/gelf-php-test/blob/master/composer.json) to import [my fork of gelf-php](http://github.com/msabramo/gelf-php) into a project.
