### PR TITLE
Add a Gelf namespace

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,9 +1,12 @@
 <?php
 
-require('GELFMessage.php');
-require('GELFMessagePublisher.php');
+set_include_path(get_include_path() . PATH_SEPARATOR . 'src');
+spl_autoload_register();
 
-$message = new GELFMessage();
+use Gelf\Message;
+use Gelf\MessagePublisher;
+
+$message = new Message();
 $message->setShortMessage('something is broken.');
 $message->setFullMessage("lol full message!");
 $message->setHost('somehost');
@@ -13,5 +16,5 @@ $message->setLine(1337);
 $message->setAdditional("something", "foo");
 $message->setAdditional("something_else", "bar");
 
-$publisher = new GELFMessagePublisher('172.16.22.30');
+$publisher = new MessagePublisher('172.16.22.30');
 $publisher->publish($message);

--- a/src/Gelf/IMessagePublisher.php
+++ b/src/Gelf/IMessagePublisher.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Gelf;
+
+interface IMessagePublisher {
+    /**
+     * Publishes a Message, returns false if an error occured during write
+     *
+     * @throws UnexpectedValueException
+     * @param unknown_type $message
+     * @return boolean
+     */
+    public function publish(Message $message);
+}

--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -1,9 +1,12 @@
 <?php
-class GELFMessage {
+
+namespace Gelf;
+
+class Message {
     /**
      * @var string
      */
-    private $version = null;
+    private $version = '1.0';
 
     /**
      * @var integer
@@ -52,7 +55,7 @@ class GELFMessage {
 
     /**
      * @param string $version
-     * @return GELFMessage
+     * @return Message
      */
     public function setVersion($version) {
         $this->version = $version;
@@ -68,7 +71,7 @@ class GELFMessage {
 
     /**
      * @param integer $timestamp
-     * @return GELFMessage
+     * @return Message
      */
     public function setTimestamp($timestamp) {
         $this->timestamp = $timestamp;
@@ -84,7 +87,7 @@ class GELFMessage {
 
     /**
      * @param string $shortMessage
-     * @return GELFMessage
+     * @return Message
      */
     public function setShortMessage($shortMessage) {
         $this->shortMessage = $shortMessage;
@@ -100,7 +103,7 @@ class GELFMessage {
 
     /**
      * @param string $fullMessage
-     * @return GELFMessage
+     * @return Message
      */
     public function setFullMessage($fullMessage) {
         $this->fullMessage = $fullMessage;
@@ -116,7 +119,7 @@ class GELFMessage {
 
     /**
      * @param string $facility
-     * @return GELFMessage
+     * @return Message
      */
     public function setFacility($facility) {
         $this->facility = $facility;
@@ -132,7 +135,7 @@ class GELFMessage {
 
     /**
      * @param string $host
-     * @return GELFMessage
+     * @return Message
      */
     public function setHost($host) {
         $this->host = $host;
@@ -148,7 +151,7 @@ class GELFMessage {
 
     /**
      * @param integer $level
-     * @return GELFMessage
+     * @return Message
      */
     public function setLevel($level) {
         $this->level = $level;
@@ -164,7 +167,7 @@ class GELFMessage {
 
     /**
      * @param string $file
-     * @return GELFMessage
+     * @return Message
      */
     public function setFile($file) {
         $this->file = $file;
@@ -180,7 +183,7 @@ class GELFMessage {
 
     /**
      * @param integer $line
-     * @return GELFMessage
+     * @return Message
      */
     public function setLine($line) {
         $this->line = $line;
@@ -197,7 +200,7 @@ class GELFMessage {
     /**
      * @param string $key
      * @param mixed $value
-     * @return GELFMessage
+     * @return Message
      */
     public function setAdditional($key, $value) {
         $this->data["_" . trim($key)] = $value;

--- a/src/Gelf/MessagePublisher.php
+++ b/src/Gelf/MessagePublisher.php
@@ -2,7 +2,7 @@
 
 namespace Gelf;
 
-class MessagePublisher {
+class MessagePublisher implements IMessagePublisher {
     /**
      * @var integer
      */

--- a/src/Gelf/MessagePublisher.php
+++ b/src/Gelf/MessagePublisher.php
@@ -1,5 +1,8 @@
 <?php
-class GELFMessagePublisher {
+
+namespace Gelf;
+
+class MessagePublisher {
     /**
      * @var integer
      */
@@ -38,7 +41,7 @@ class GELFMessagePublisher {
     /**
      * Creates a new publisher that sends errors to a Graylog2 server via UDP
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @param string $hostname
      * @param integer $port
      * @param integer $chunkSize
@@ -46,15 +49,15 @@ class GELFMessagePublisher {
     public function __construct($hostname, $port = self::GRAYLOG2_DEFAULT_PORT, $chunkSize = self::CHUNK_SIZE_WAN) {
         // Check whether the parameters are set correctly
         if(!$hostname) {
-            throw new InvalidArgumentException('$hostname must be set');
+            throw new \InvalidArgumentException('$hostname must be set');
         }
 
         if(!is_numeric($port)) {
-            throw new InvalidArgumentException('$port must be an integer');
+            throw new \InvalidArgumentException('$port must be an integer');
         }
 
         if(!is_numeric($chunkSize)) {
-            throw new InvalidArgumentException('$chunkSize must be an integer');
+            throw new \InvalidArgumentException('$chunkSize must be an integer');
         }
 
         $this->hostname = $hostname;
@@ -63,16 +66,16 @@ class GELFMessagePublisher {
     }
 
     /**
-     * Publishes a GELFMessage, returns false if an error occured during write
+     * Publishes a Message, returns false if an error occured during write
      *
      * @throws UnexpectedValueException
      * @param unknown_type $message
      * @return boolean
      */
-    public function publish(GELFMessage $message) {
+    public function publish(Message $message) {
         // Check if required message parameters are set
         if(!$message->getShortMessage() || !$message->getHost()) {
-            throw new UnexpectedValueException(
+            throw new \UnexpectedValueException(
                 'Missing required data parameter: "version", "short_message" and "host" are required.'
             );
         }
@@ -127,10 +130,10 @@ class GELFMessagePublisher {
     }
 
     /**
-     * @param GELFMessage $message
+     * @param Message $message
      * @return string
      */
-    protected function getPreparedMessage(GELFMessage $message) {
+    protected function getPreparedMessage(Message $message) {
         return gzcompress(json_encode($message->toArray()));
     }
 
@@ -169,24 +172,24 @@ class GELFMessagePublisher {
      * @param string $data
      * @param integer $sequence
      * @param integer $sequenceSize
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @return string
      */
     protected function prependChunkInformation($messageId, $data, $sequence, $sequenceSize) {
         if(!is_string($data) || $data === '') {
-            throw new InvalidArgumentException('Data must be a string and not be empty.');
+            throw new \InvalidArgumentException('Data must be a string and not be empty.');
         }
 
         if(!is_integer($sequence) || !is_integer($sequenceSize)) {
-            throw new InvalidArgumentException('Sequence number and size must be integer.');
+            throw new \InvalidArgumentException('Sequence number and size must be integer.');
         }
 
         if($sequenceSize <= 0) {
-            throw new InvalidArgumentException('Sequence size must be greater than 0.');
+            throw new \InvalidArgumentException('Sequence size must be greater than 0.');
         }
 
         if($sequence > $sequenceSize) {
-            throw new InvalidArgumentException('Sequence size must be greater than sequence number.');
+            throw new \InvalidArgumentException('Sequence size must be greater than sequence number.');
         }
 
         return pack('CC', 30, 15) . substr(md5($messageId, true), 0, 8) . pack('CC', $sequence, $sequenceSize) . $data;


### PR DESCRIPTION
d584008 - Namespaces are cool and they also enable nice [autoloading](http://getcomposer.org/doc/01-basic-usage.md#autoloading) with [Composer](http://getcomposer.org/) (see https://github.com/Graylog2/gelf-php/pull/9)

c0e0250 - Adds an interface called `IMessagePublisher` so that things like type hints and unit tests can rely on an abstraction rather than a concrete class (example need for this at https://github.com/Seldaek/monolog/pull/61#r478588)
