### PR TITLE
Add support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+
+php:
+  - 5.2
+  - 5.3
+  - 5.4
+
+script: phpunit

--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-PHP classes to send GELF (Graylog extended log format) messages
-
-See http://www.graylog2.org/about/gelf for more information.

--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,7 @@
+# gelf-php
+
+[![Build Status](https://secure.travis-ci.org/Graylog2/gelf-php.png?branch=master)](http://travis-ci.org/Graylog2/gelf-php)
+
+PHP classes to send GELF (Graylog extended log format) messages
+
+See http://www.graylog2.org/about/gelf for more information.


### PR DESCRIPTION
Note that the Travis build will fail if there are no PHPUnit tests so this pull request depends on https://github.com/Graylog2/gelf-php/pull/11 which adds a PHPUnit test.
