### PR TITLE
Added log level constants

### DIFF
--- a/GELFMessage.php
+++ b/GELFMessage.php
@@ -1,5 +1,18 @@
 <?php
 class GELFMessage {
+    /**#@+
+     *    Log levels according to syslog priority
+     */
+    const EMERGENCY = 0;
+    const ALERT = 1;
+    const CRITICAL = 2;
+    const ERROR = 3;
+    const WARNING = 4;
+    const NOTICE = 5;
+    const INFO = 6;
+    const DEBUG = 7;
+    /**#@-*/
+    
     /**
      * @var string
      */

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ $message = new GELFMessage();
 $message->setShortMessage('something is broken.');
 $message->setFullMessage("lol full message!");
 $message->setHost('somehost');
-$message->setLevel(2);
+$message->setLevel(GELFMessage::CRITICAL);
 $message->setFile('/var/www/example.php');
 $message->setLine(1337);
 $message->setAdditional("something", "foo");

--- a/tests/GelfMessageTest.php
+++ b/tests/GelfMessageTest.php
@@ -12,7 +12,7 @@ class GelfMessageTest extends PHPUnit_Framework_TestCase
         $message->setShortMessage('something is broken.');
         $message->setFullMessage("lol full message!");
         $message->setHost('somehost');
-        $message->setLevel(2);
+        $message->setLevel(GELFMessage::CRITICAL);
         $message->setFile('/var/www/example.php');
         $message->setLine(1337);
         $message->setAdditional("something", "foo");
@@ -26,7 +26,7 @@ class GelfMessageTest extends PHPUnit_Framework_TestCase
                 'full_message' => 'lol full message!',
                 'facility' => null,
                 'host' => 'somehost',
-                'level' => 2,
+                'level' => GELFMessage::CRITICAL,
                 'file' => '/var/www/example.php',
                 'line' => 1337,
                 '_something' => 'foo',


### PR DESCRIPTION
Added log level constants for GELFMessages which make the usage more readable

``` php
setLevel(GELFMessage::CRITICAL)
```

instead of 

``` php
setLevel(2)
```
