### PR TITLE
GELFMessage::getAdditional not getting value set by setAdditional

### DIFF
--- a/GELFMessage.php
+++ b/GELFMessage.php
@@ -221,7 +221,8 @@ class GELFMessage {
      * @return mixed
      */
     public function getAdditional($key) {
-        return isset($this->data["_" . trim($key)]) ? $this->data[$key] : null;
+        $additional_key = "_" . trim($key);
+        return isset($this->data[$additional_key]) ? $this->data[$additional_key] : null;
     }
 
     /**

--- a/tests/GelfMessageTest.php
+++ b/tests/GelfMessageTest.php
@@ -35,5 +35,11 @@ class GelfMessageTest extends PHPUnit_Framework_TestCase
             $message->toArray()
         );
     }
+
+    public function testAdditionalField() {
+        $message = new GELFMessage();
+        $message->setAdditional("something", "foo");
+        $this->assertEquals("foo", $message->getAdditional("something"));
+    }
 }
 


### PR DESCRIPTION
The getter for additional values did not return the value checked for and used by the setter. This is now fixed, a unit test has been added to ensure valid behaviour.
